### PR TITLE
Legion money fixes

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -161,7 +161,7 @@ Veteran Decan
 		/obj/item/reagent_containers/pill/patch/healingpowder=2, \
 		/obj/item/ammo_box/a762/doublestacked=3, \
 		/obj/item/flashlight/flare/torch=1, \
-		/obj/item/storage/bag/money/small/legofficer)
+		/obj/item/storage/bag/money/small/legofficers)
 
 
 /*
@@ -199,7 +199,7 @@ Prime Decan
 		/obj/item/reagent_containers/pill/patch/healingpowder=2, \
 		/obj/item/ammo_box/magazine/m10mm_adv=2, \
 		/obj/item/flashlight/flare/torch=1, \
-		/obj/item/storage/bag/money/small/legofficer)
+		/obj/item/storage/bag/money/small/legofficers)
 
 
 /*
@@ -237,7 +237,7 @@ Decan
 		/obj/item/reagent_containers/pill/patch/healingpowder=2, \
 		/obj/item/ammo_box/m44=2, \
 		/obj/item/flashlight/flare/torch=1, \
-		/obj/item/storage/bag/money/small/legofficer)
+		/obj/item/storage/bag/money/small/legofficers)
 
 
 /*

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -161,7 +161,7 @@ Veteran Decan
 		/obj/item/reagent_containers/pill/patch/healingpowder=2, \
 		/obj/item/ammo_box/a762/doublestacked=3, \
 		/obj/item/flashlight/flare/torch=1, \
-		/obj/item/stack/f13Cash/random/denarius/legionpay_officer)
+		/obj/item/storage/bag/money/small/legofficer)
 
 
 /*
@@ -199,7 +199,7 @@ Prime Decan
 		/obj/item/reagent_containers/pill/patch/healingpowder=2, \
 		/obj/item/ammo_box/magazine/m10mm_adv=2, \
 		/obj/item/flashlight/flare/torch=1, \
-		/obj/item/stack/f13Cash/random/denarius/legionpay_officer)
+		/obj/item/storage/bag/money/small/legofficer)
 
 
 /*
@@ -237,7 +237,7 @@ Decan
 		/obj/item/reagent_containers/pill/patch/healingpowder=2, \
 		/obj/item/ammo_box/m44=2, \
 		/obj/item/flashlight/flare/torch=1, \
-		/obj/item/stack/f13Cash/random/denarius/legionpay_officer)
+		/obj/item/storage/bag/money/small/legofficer)
 
 
 /*
@@ -279,7 +279,7 @@ Vexillarius
 		/obj/item/ammo_box/a762/doublestacked=2, \
 		/obj/item/flashlight/flare/torch=1, \
 		/obj/item/megaphone/cornu=1, \
-		/obj/item/stack/f13Cash/random/denarius/legionpay_officer)
+		/obj/item/storage/bag/money/small/legenlisted)
 
 /*
 Veteran
@@ -321,7 +321,7 @@ Veteran
 		/obj/item/storage/box/lethalshot, \
 		/obj/item/reagent_containers/pill/patch/healingpowder=2, \
 		/obj/item/flashlight/flare/torch=1, \
-		/obj/item/stack/f13Cash/random/denarius/legionpay_veteran)
+		/obj/item/storage/bag/money/small/legenlisted)
 
 
 /*
@@ -360,7 +360,7 @@ Prime
 		/obj/item/ammo_box/m44=2, \
 		/obj/item/reagent_containers/pill/patch/healingpowder=2, \
 		/obj/item/flashlight/flare/torch=1, \
-		/obj/item/stack/f13Cash/random/denarius/legionpay_veteran)
+		/obj/item/storage/bag/money/small/legenlisted)
 
 
 /*
@@ -396,8 +396,7 @@ Legionary
 		/obj/item/restraints/handcuffs=1, \
 		/obj/item/claymore/machete=1, \
 		/obj/item/reagent_containers/pill/patch/healingpowder=2, \
-		/obj/item/flashlight/flare/torch=1, \
-		/obj/item/stack/f13Cash/random/denarius/legionpay_basic)
+		/obj/item/flashlight/flare/torch=1)
 
 
 /datum/job/CaesarsLegion/Legionnaire/f13explorer
@@ -433,7 +432,7 @@ Legionary
 		/obj/item/ammo_box/a762/doublestacked=2, \
 		/obj/item/reagent_containers/pill/patch/healingpowder=2, \
 		/obj/item/flashlight/flare/torch=1, \
-		/obj/item/stack/f13Cash/random/denarius/legionpay_veteran)
+		/obj/item/storage/bag/money/small/legenlisted)
 	r_pocket = /obj/item/binocs
 
 /datum/job/CaesarsLegion/Legionnaire/f13scout
@@ -469,7 +468,7 @@ Legionary
 		/obj/item/reagent_containers/pill/patch/healingpowder=2, \
 		/obj/item/ammo_box/a762=2, \
 		/obj/item/flashlight/flare/torch=1, \
-		/obj/item/stack/f13Cash/random/denarius/legionpay_basic)
+		/obj/item/storage/bag/money/small/legenlisted)
 
 /datum/job/CaesarsLegion/f13campfollower
 	title = "Camp Follower"

--- a/code/modules/mining/money_bag.dm
+++ b/code/modules/mining/money_bag.dm
@@ -45,9 +45,19 @@
 
 // Legion reserves. Spawns with the Centurion.
 /obj/item/storage/bag/money/small/legion/PopulateContents()
-	// ~600 worth of legion money
+	// ~500ish worth of legion money
 	new /obj/item/stack/f13Cash/random/denarius/high(src)
-	new /obj/item/stack/f13Cash/random/aureus/high(src)
+	new /obj/item/stack/f13Cash/random/aureus/med(src)
+	
+// Legion enlisted. Spawns with the Legionnaires.
+/obj/item/storage/bag/money/small/legenlisted/PopulateContents()
+	new /obj/item/stack/f13Cash/random/denarius/low(src)
+	new /obj/item/stack/f13Cash/random/denarius/low(src)
+	
+// Legion officers. Spawns with the Decanii.
+/obj/item/storage/bag/money/small/legofficers/PopulateContents()
+	new /obj/item/stack/f13Cash/random/denarius/med(src)
+	new /obj/item/stack/f13Cash/random/aureus/low(src)
 
 // NCR reserves. Spawns with the Captain.
 /obj/item/storage/bag/money/small/ncr/PopulateContents()
@@ -90,9 +100,4 @@
 /obj/item/storage/bag/money/small/raider/PopulateContents()
 	// ~12 worth of caps
 	new /obj/item/stack/f13Cash/random/bottle_cap/low(src)
-
-// Legion don't start with a money bag, they just have a few loose coins in their backpack.
-	// see legion.dm
-	// officers get ~18 worth of denarius
-	// veterans get ~12 worth of denarius
-	// basic bois get ~6 worth of denarius
+	


### PR DESCRIPTION

## Description
Fixes the failed spawning of money for legion jobs.

## Motivation and Context
In the code, legionnaires are supposed to get money, but no pouch. Unfortunately the stacks don't like to spawn unless they're inside a money pouch, so I mirrored the NCR money spawning pouches with varying amounts of money based on role. 

## How Has This Been Tested?
Opened up a local test and joined as centurion to ensure I didn't break the already working one, then joined decanus and legionnaire roles to check if the money bag spawned in their backpack with the correct amount.

## Screenshots (if appropriate): 
![CENTURION](https://user-images.githubusercontent.com/46360163/58686073-5abe9e00-8343-11e9-9d9a-b859aa44737b.png)
![DECANUS](https://user-images.githubusercontent.com/46360163/58686074-5abe9e00-8343-11e9-82b7-d9db3af88a94.png)
![LEGIONNAIRE](https://user-images.githubusercontent.com/46360163/58686075-5abe9e00-8343-11e9-919c-dc87f5b1786c.png)

## Changelog
:cl:
fix: Rejoice Legion hagglers! Legion jobs now spawn with varying amounts of denarii and aureii depending on your role. Unfortunately the Legion does not view its recruits as deserving of this privilege, as the Legion provides everything they should ever need until they prove themselves.
/:cl:
