### PR TITLE
Legion armor changes v2

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -413,11 +413,11 @@
 	dynamic_fhair_suffix = ""
 
 /obj/item/clothing/head/helmet/f13/legion/legdecan
-	name = "legion decanus helmet"
-	desc = "It's leather legion decan helmet."
+	name = "legion recruit decanus helmet"
+	desc = "It's leather legion recruit decan helmet."
 	icon_state = "legdecan"
 	item_state = "legdecan"
-	armor = list("melee" = 60, "bullet" = 40, "laser" = 25, "energy" = 15, "bomb" = 25, "bio" = 50, "rad" = 0, "fire" = 70, "acid" = 0)
+	armor = list("melee" = 40, "bullet" = 25, "laser" = 10, "energy" = 10, "bomb" = 16, "bio" = 30, "rad" = 0, "fire" = 50, "acid" = 0)
 	flags_inv = HIDEEARS|HIDEHAIR
 	strip_delay = 50
 	resistance_flags = LAVA_PROOF | FIRE_PROOF

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -466,6 +466,7 @@
 
 /obj/item/clothing/suit/armor/f13/legrecruit/vet
 	name = "legion veteran armor"
+	desc = "Armor worn by veteran legionaries who have proven their combat prowess in many battles, its hardened leather is sturdier than that of previous ranks."
 	item_state = "legveteran"
 	armor = list("melee" = 60, "bullet" = 40, "laser" = 25, "energy" = 15, "bomb" = 25, "bio" = 50, "rad" = 0, "fire" = 70, "acid" = 0)
 


### PR DESCRIPTION

## Description
Changes the armor value of the recruit decanus helmet to match the scaling of other helmets, it was made as protective as the veteran decanus helmet, which I believe to be an oversight. Also changed the name and description to mention the rank instead of just "decanus".
Changes the description of legion veteran armor as none was given, defaulting it to recruit armor description.

## Motivation and Context
Just fixes an oversight of armor values and a missing description. The motivation is my legion bia- desire to fix small issues that are in my power.

## How Has This Been Tested?
Just opened a local game and ensured the helmet was working properly, also examined veteran armor to make sure the description was correctly altered.

## Changelog (neccesary)
:cl:
tweak: Recruit decanus helmet values made to match recruit, instead of veteran, armor values. Recruit decanus helmet is now named as such to denote recruit rank on examination. Legion veteran armor now has its own description.
/:cl:
